### PR TITLE
feat: add CA and NY state tax engines

### DIFF
--- a/src/components/forms/PersonalInfoForm.js
+++ b/src/components/forms/PersonalInfoForm.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { marylandCountyRates } from '../../constants/taxBrackets';
 
-const PersonalInfoForm = ({ 
-  personalInfo, 
-  onChange, 
-  t, 
+const PersonalInfoForm = ({
+  personalInfo,
+  onChange,
+  t,
   UncontrolledInput,
-  onShowSpouseDialog 
+  onShowSpouseDialog
 }) => {
   const countyOptions = Object.keys(marylandCountyRates).sort();
 
@@ -29,7 +29,7 @@ const PersonalInfoForm = ({
             placeholder={t('personalInfo.placeholders.firstName')}
           />
         </div>
-        
+
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-2">
             {t('personalInfo.lastName')} <span className="text-red-500">*</span>
@@ -41,7 +41,7 @@ const PersonalInfoForm = ({
             placeholder={t('personalInfo.placeholders.lastName')}
           />
         </div>
-        
+
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-2">
             {t('personalInfo.ssn')} <span className="text-red-500">*</span>
@@ -54,7 +54,7 @@ const PersonalInfoForm = ({
             help={t('personalInfo.help.ssn')}
           />
         </div>
-        
+
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-2">
             {t('personalInfo.filingStatus')}
@@ -72,7 +72,7 @@ const PersonalInfoForm = ({
           <div className="text-gray-500 text-xs mt-1">
             💡 {t('personalInfo.help.filingStatus')}
           </div>
-          
+
           {/* Add Spouse Button for Married Filing Jointly */}
           {personalInfo.filingStatus === 'marriedJointly' && (
             <button
@@ -86,7 +86,7 @@ const PersonalInfoForm = ({
             </button>
           )}
         </div>
-        
+
         <div className="lg:col-span-2">
           <label className="block text-sm font-medium text-gray-700 mb-2">
             {t('personalInfo.address')} <span className="text-red-500">*</span>
@@ -98,7 +98,7 @@ const PersonalInfoForm = ({
             placeholder={t('personalInfo.placeholders.address')}
           />
         </div>
-        
+
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-2">
             {t('personalInfo.dependents')}
@@ -113,20 +113,24 @@ const PersonalInfoForm = ({
             help={t('personalInfo.help.dependents')}
           />
         </div>
-        
+
         <div>
-          <label className="flex items-center space-x-2 text-sm font-medium text-gray-700">
-            <input
-              type="checkbox"
-              checked={personalInfo.isMaryland}
-              onChange={(e) => handleInputChange('isMaryland', e.target.checked)}
-              className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-            />
-            <span>{t('personalInfo.marylandResident')}</span>
-          </label>
+          <label className="block text-sm font-medium text-gray-700 mb-2">State</label>
+          <select
+            value={personalInfo.state}
+            onChange={(e) => {
+              handleInputChange('state', e.target.value);
+              handleInputChange('isMaryland', e.target.value === 'MD');
+            }}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm sm:text-base"
+          >
+            <option value="MD">Maryland</option>
+            <option value="CA">California</option>
+            <option value="NY">New York</option>
+          </select>
         </div>
-        
-        {personalInfo.isMaryland && (
+
+        {personalInfo.state === 'MD' && (
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">
               {t('personalInfo.county')}

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -10,19 +10,23 @@ export {
   ADDITIONAL_STANDARD_DEDUCTION_2025,
   SALT_CAP_2025 
 } from './rules/2025/federal/deductions';
-export { 
-  CTC_2025, 
-  EITC_2025, 
-  AOTC_2025, 
-  LLC_2025 
+export {
+  CTC_2025,
+  EITC_2025,
+  AOTC_2025,
+  LLC_2025
 } from './rules/2025/federal/credits';
 export { MD_RULES_2025 } from './rules/2025/states/md';
+export { CA_RULES_2025 } from './rules/2025/states/ca';
+export { NY_RULES_2025 } from './rules/2025/states/ny';
 
 // Calculator exports
 export { computeFederal2025 } from './federal/2025/computeFederal2025';
-export { 
-  computeMD2025, 
+export {
+  computeMD2025,
   isMarylandResident,
   getMarylandCounties,
-  getMDLocalRate 
+  getMDLocalRate
 } from './states/md/2025/computeMD2025';
+export { computeCA2025, isCaliforniaResident } from './states/ca/2025/computeCA2025';
+export { computeNY2025, isNewYorkResident } from './states/ny/2025/computeNY2025';

--- a/src/engine/rules/2025/states/ca.ts
+++ b/src/engine/rules/2025/states/ca.ts
@@ -1,0 +1,21 @@
+import { dollarsToCents } from '../../../util/money';
+import { TaxBracket } from '../../../types';
+
+// California tax rules for 2025 (simplified)
+export const CA_RULES_2025 = {
+  standardDeduction: {
+    single: dollarsToCents(5202),
+    marriedJointly: dollarsToCents(10404),
+    marriedSeparately: dollarsToCents(5202),
+    headOfHousehold: dollarsToCents(10404),
+  },
+
+  brackets: [
+    { min: 0, max: dollarsToCents(10000), rate: 0.01 },
+    { min: dollarsToCents(10000), max: dollarsToCents(50000), rate: 0.02 },
+    { min: dollarsToCents(50000), max: Infinity, rate: 0.04 },
+  ] as TaxBracket[],
+
+  // California EITC percentage of federal EITC (simplified)
+  eitcPercentage: 0.15,
+};

--- a/src/engine/rules/2025/states/ny.ts
+++ b/src/engine/rules/2025/states/ny.ts
@@ -1,0 +1,22 @@
+import { dollarsToCents } from '../../../util/money';
+import { TaxBracket } from '../../../types';
+
+// New York tax rules for 2025 (simplified)
+export const NY_RULES_2025 = {
+  standardDeduction: {
+    single: dollarsToCents(8000),
+    marriedJointly: dollarsToCents(16050),
+    marriedSeparately: dollarsToCents(8000),
+    headOfHousehold: dollarsToCents(11200),
+  },
+
+  brackets: [
+    { min: 0, max: dollarsToCents(8500), rate: 0.04 },
+    { min: dollarsToCents(8500), max: dollarsToCents(11700), rate: 0.045 },
+    { min: dollarsToCents(11700), max: dollarsToCents(13900), rate: 0.0525 },
+    { min: dollarsToCents(13900), max: Infinity, rate: 0.059 },
+  ] as TaxBracket[],
+
+  // New York EITC percentage of federal EITC (simplified)
+  eitcPercentage: 0.30,
+};

--- a/src/engine/states/ca/2025/computeCA2025.ts
+++ b/src/engine/states/ca/2025/computeCA2025.ts
@@ -1,0 +1,45 @@
+import { TaxPayerInput, StateResult, FederalResult2025 } from '../../../types';
+import { CA_RULES_2025 } from '../../../rules/2025/states/ca';
+import { max0, safeCurrencyToCents, multiplyCents } from '../../../util/money';
+import { calculateTaxFromBrackets } from '../../../util/math';
+
+/**
+ * Compute California state tax for 2025 (simplified)
+ */
+export function computeCA2025(
+  input: TaxPayerInput,
+  federalResult: FederalResult2025
+): StateResult {
+  const caAGI = federalResult.agi;
+
+  const standardDeduction =
+    CA_RULES_2025.standardDeduction[
+      input.filingStatus as keyof typeof CA_RULES_2025.standardDeduction
+    ] || CA_RULES_2025.standardDeduction.single;
+
+  const taxableIncome = max0(caAGI - standardDeduction);
+  const stateTax = calculateTaxFromBrackets(taxableIncome, CA_RULES_2025.brackets);
+  const caEITC = multiplyCents(
+    federalResult.credits.eitc || 0,
+    CA_RULES_2025.eitcPercentage
+  );
+  const netStateTax = max0(stateTax - caEITC);
+  const stateWithheld = safeCurrencyToCents(input.payments?.stateWithheld);
+  const totalStateLiability = netStateTax;
+  const stateRefundOrOwe = stateWithheld - totalStateLiability;
+
+  return {
+    state: 'CA',
+    year: 2025,
+    agiState: caAGI,
+    taxableIncomeState: taxableIncome,
+    stateTax: netStateTax,
+    totalStateLiability,
+    stateWithheld,
+    stateRefundOrOwe,
+  };
+}
+
+export function isCaliforniaResident(input: TaxPayerInput): boolean {
+  return input.state === 'CA';
+}

--- a/src/engine/states/ca/__tests__/computeCA2025.test.ts
+++ b/src/engine/states/ca/__tests__/computeCA2025.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { computeCA2025 } from '../2025/computeCA2025';
+import { CA_RULES_2025 } from '../../../rules/2025/states/ca';
+import { FederalResult2025, TaxPayerInput } from '../../../types';
+
+const baseFederal: FederalResult2025 = {
+  agi: 6000000,
+  taxableIncome: 6000000,
+  standardDeduction: 0,
+  taxBeforeCredits: 0,
+  credits: {},
+  totalTax: 0,
+  totalPayments: 0,
+  refundOrOwe: 0,
+};
+
+describe('computeCA2025', () => {
+  it('calculates California tax with standard deduction', () => {
+    const input: TaxPayerInput = {
+      filingStatus: 'single',
+      primary: {},
+      income: {},
+      payments: {},
+      state: 'CA',
+    } as any;
+    const result = computeCA2025(input, baseFederal);
+    expect(result.state).toBe('CA');
+    const expectedTaxable = baseFederal.agi - CA_RULES_2025.standardDeduction.single;
+    expect(result.taxableIncomeState).toBe(expectedTaxable);
+    expect(result.stateTax).toBeGreaterThan(0);
+  });
+});

--- a/src/engine/states/ny/2025/computeNY2025.ts
+++ b/src/engine/states/ny/2025/computeNY2025.ts
@@ -1,0 +1,45 @@
+import { TaxPayerInput, StateResult, FederalResult2025 } from '../../../types';
+import { NY_RULES_2025 } from '../../../rules/2025/states/ny';
+import { max0, safeCurrencyToCents, multiplyCents } from '../../../util/money';
+import { calculateTaxFromBrackets } from '../../../util/math';
+
+/**
+ * Compute New York state tax for 2025 (simplified)
+ */
+export function computeNY2025(
+  input: TaxPayerInput,
+  federalResult: FederalResult2025
+): StateResult {
+  const nyAGI = federalResult.agi;
+
+  const standardDeduction =
+    NY_RULES_2025.standardDeduction[
+      input.filingStatus as keyof typeof NY_RULES_2025.standardDeduction
+    ] || NY_RULES_2025.standardDeduction.single;
+
+  const taxableIncome = max0(nyAGI - standardDeduction);
+  const stateTax = calculateTaxFromBrackets(taxableIncome, NY_RULES_2025.brackets);
+  const nyEITC = multiplyCents(
+    federalResult.credits.eitc || 0,
+    NY_RULES_2025.eitcPercentage
+  );
+  const netStateTax = max0(stateTax - nyEITC);
+  const stateWithheld = safeCurrencyToCents(input.payments?.stateWithheld);
+  const totalStateLiability = netStateTax;
+  const stateRefundOrOwe = stateWithheld - totalStateLiability;
+
+  return {
+    state: 'NY',
+    year: 2025,
+    agiState: nyAGI,
+    taxableIncomeState: taxableIncome,
+    stateTax: netStateTax,
+    totalStateLiability,
+    stateWithheld,
+    stateRefundOrOwe,
+  };
+}
+
+export function isNewYorkResident(input: TaxPayerInput): boolean {
+  return input.state === 'NY';
+}

--- a/src/engine/states/ny/__tests__/computeNY2025.test.ts
+++ b/src/engine/states/ny/__tests__/computeNY2025.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { computeNY2025 } from '../2025/computeNY2025';
+import { NY_RULES_2025 } from '../../../rules/2025/states/ny';
+import { FederalResult2025, TaxPayerInput } from '../../../types';
+
+const baseFederal: FederalResult2025 = {
+  agi: 6000000,
+  taxableIncome: 6000000,
+  standardDeduction: 0,
+  taxBeforeCredits: 0,
+  credits: {},
+  totalTax: 0,
+  totalPayments: 0,
+  refundOrOwe: 0,
+};
+
+describe('computeNY2025', () => {
+  it('calculates New York tax with standard deduction', () => {
+    const input: TaxPayerInput = {
+      filingStatus: 'single',
+      primary: {},
+      income: {},
+      payments: {},
+      state: 'NY',
+    } as any;
+    const result = computeNY2025(input, baseFederal);
+    expect(result.state).toBe('NY');
+    const expectedTaxable = baseFederal.agi - NY_RULES_2025.standardDeduction.single;
+    expect(result.taxableIncomeState).toBe(expectedTaxable);
+    expect(result.stateTax).toBeGreaterThan(0);
+  });
+});

--- a/src/hooks/useTaxCalculator.js
+++ b/src/hooks/useTaxCalculator.js
@@ -15,6 +15,7 @@ export const useTaxCalculator = () => {
     filingStatus: 'single',
     address: '',
     dependents: 0,
+    state: 'MD',
     isMaryland: true,
     county: 'Baltimore City'
   });
@@ -158,7 +159,11 @@ export const useTaxCalculator = () => {
   }, [personalInfo, incomeData, k1Data, businessDetails, paymentsData, deductions, spouseInfo]);
 
   const handlePersonalInfoChange = (field, value) => {
-    setPersonalInfo(prev => ({ ...prev, [field]: value }));
+    setPersonalInfo(prev => ({
+      ...prev,
+      [field]: value,
+      ...(field === 'state' ? { isMaryland: value === 'MD' } : {})
+    }));
   };
 
   const handleSpouseInfoChange = (field, value) => {

--- a/src/utils/engineAdapter.ts
+++ b/src/utils/engineAdapter.ts
@@ -6,15 +6,17 @@ let computeFederal1040 = null, convertUIToFederal1040Input = null;
 console.log('🔧 Advanced Federal 1040 engine temporarily disabled - under development');
 
 // Legacy engine fallback
-let computeFederal2025, computeMD2025;
+let computeFederal2025;
+const stateEngines: Record<string, any> = {};
 try {
   const engine = require('../engine-dist/index.js');
   computeFederal2025 = engine.computeFederal2025;
-  computeMD2025 = engine.computeMD2025;
+  stateEngines.MD = engine.computeMD2025;
+  stateEngines.CA = engine.computeCA2025;
+  stateEngines.NY = engine.computeNY2025;
 } catch (error) {
   console.warn('Legacy engine not available:', error.message);
   computeFederal2025 = null;
-  computeMD2025 = null;
 }
 
 /**
@@ -31,9 +33,9 @@ export function convertUIToEngineInput(personalInfo, incomeData, k1Data, busines
     dependents: parseInt(personalInfo.dependents) || 0,
     
     // Location info
-    state: personalInfo.isMaryland ? 'MD' : personalInfo.state,
+    state: personalInfo.state,
     county: personalInfo.county,
-    isMaryland: personalInfo.isMaryland,
+    isMaryland: personalInfo.state === 'MD',
     
     income: {
       wages: parseFloat(incomeData.wages) || 0,
@@ -239,7 +241,7 @@ export function calculateTaxResultsWithEngine(personalInfo, incomeData, k1Data, 
     }
     
     // Priority 2: Use legacy engine if available
-    else if (computeFederal2025 && computeMD2025) {
+    else if (computeFederal2025) {
       console.log('⚡ Using legacy tax engine');
       
       // Convert UI data to engine format
@@ -256,10 +258,11 @@ export function calculateTaxResultsWithEngine(personalInfo, incomeData, k1Data, 
       // Calculate federal taxes
       const federalResult = computeFederal2025(engineInput);
       
-      // Calculate state taxes if Maryland resident
+      // Calculate state taxes if engine available
       let stateResult = null;
-      if (personalInfo.isMaryland) {
-        stateResult = computeMD2025(engineInput, federalResult);
+      const computeState = stateEngines[personalInfo.state];
+      if (computeState) {
+        stateResult = computeState(engineInput, federalResult);
       }
       
       // Convert back to UI format
@@ -342,7 +345,7 @@ export function calculateFilingComparisonWithEngine(personalInfo, incomeData, sp
   
   try {
     // Use engine if available, otherwise fallback to original calculations
-    if (computeFederal2025 && computeMD2025) {
+    if (computeFederal2025) {
       console.log('Using advanced engine for filing comparison');
       
       // Create base input
@@ -359,7 +362,8 @@ export function calculateFilingComparisonWithEngine(personalInfo, incomeData, sp
       // Calculate joint filing
       const jointInput = { ...baseInput, filingStatus: 'marriedJointly' };
       const jointFederal = computeFederal2025(jointInput);
-      const jointState = personalInfo.isMaryland ? computeMD2025(jointInput, jointFederal) : null;
+      const computeState = stateEngines[personalInfo.state];
+      const jointState = computeState ? computeState(jointInput, jointFederal) : null;
       
       // Calculate separate filing (simplified - assumes equal split)
       const separateInput = { 
@@ -382,7 +386,7 @@ export function calculateFilingComparisonWithEngine(personalInfo, incomeData, sp
       };
       
       const separateFederal = computeFederal2025(separateInput);
-      const separateState = personalInfo.isMaryland ? computeMD2025(separateInput, separateFederal) : null;
+      const separateState = computeState ? computeState(separateInput, separateFederal) : null;
       
       // Calculate totals for separate filing (multiply by 2)
       const separateTotalTax = (separateFederal.totalTax + (separateState?.totalStateLiability || 0)) * 2;


### PR DESCRIPTION
## Summary
- add simplified California and New York 2025 tax rules and calculators
- export new state engines and dynamically dispatch based on selected state
- allow selecting state in personal info form and pass to engine

## Testing
- `npm run test:engine` *(fails: failing suites in existing tests)*
- `npm test -- --watchAll=false` *(fails: jest unable to parse vitest ESM imports)*

------
https://chatgpt.com/codex/tasks/task_e_68c13a6b2a0c8328a98e85407a151c6e